### PR TITLE
修复查询是否存在有赞帐号接口的返回结果

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -45,7 +45,7 @@ class Api extends AbstractAPI
             return $this->errorResponse($result);
         }
 
-        return $result['response'] ? Helper::toNull($result['response']) : $result['response'];
+        return is_array($result['response']) ? Helper::toNull($result['response']) : $result['response'];
     }
 
     private function files(array &$files)


### PR DESCRIPTION
调用检查是否存在有赞账号接口返回的结果为
`array (
  'response' => false,
)`
`array (
  'response' => true,
)`
return $result['response'] ? Helper::toNull($result['response']) : $result['response'];
此处的Helper::toNull（）需要传入的为一个数组