### PR TITLE
refactor: 兼容最新版 hanson/foundation-sdk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "ext-json": "*",
         "ext-openssl": "*",
-        "hanson/foundation-sdk": "^5.0.1 | dev-master"
+        "hanson/foundation-sdk": "^4.0.3 | ^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "ext-json": "*",
         "ext-openssl": "*",
-        "hanson/foundation-sdk": "^3.0 | ^4.0 | ^5.0 | dev-master"
+        "hanson/foundation-sdk": "^5.0.1 | dev-master"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "ext-json": "*",
         "ext-openssl": "*",
-        "hanson/foundation-sdk": "^3.0 | ^4.0 | ^5.0"
+        "hanson/foundation-sdk": "^3.0 | ^4.0 | ^5.0 | dev-master"
     },
     "autoload": {
         "psr-4": {

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -53,12 +53,15 @@ class AccessToken extends AbstractAccessToken
 
     const TOKEN_API = 'https://open.youzanyun.com/auth/token';
 
-    public function __construct($clientId, $secret, $kdtId = null)
+    public function __construct(Youzan $app)
     {
-        $this->clientId = $clientId;
-        $this->secret = $secret;
-        $this->kdtId = $kdtId;
-        $this->appId = $clientId.$kdtId;
+        $this->app = $app;
+        $config = $app->getConfig();
+
+        $this->clientId = $app->getDev() ? $config['dev_client_id'] : $config['client_id'];
+        $this->secret = $app->getDev() ? $config['dev_client_secret'] : $config['client_secret'];
+        $this->kdtId = $config['kdt_id'] ?? null;
+        $this->appId = $this->clientId.$this->kdtId;
     }
     
     public function getToken($forceRefresh = false)

--- a/src/Oauth/Oauth.php
+++ b/src/Oauth/Oauth.php
@@ -25,10 +25,7 @@ class Oauth
      */
     public function createAuthorization($token)
     {
-        $accessToken = new AccessToken(
-            $this->app->getConfig()['client_id'],
-            $this->app->getConfig()['client_secret']
-        );
+        $accessToken = new AccessToken($this->app);
 
         $accessToken->setToken($token);
 

--- a/src/Oauth/ServiceProvider.php
+++ b/src/Oauth/ServiceProvider.php
@@ -23,14 +23,8 @@ class ServiceProvider implements ServiceProviderInterface
     {
 
         $pimple['oauth.access_token'] = function (Youzan $pimple) {
-            $config = $pimple->getConfig();
-            $accessToken =  new AccessToken(
-                $pimple->getDev() ? $config['dev_client_id'] : $config['client_id'],
-                $pimple->getDev() ? $config['dev_client_secret'] : $config['client_secret']
-            );
-
+            $accessToken =  new AccessToken($pimple);
             $accessToken->setRequest($pimple['request']);
-
             $accessToken->setRedirectUri($pimple->getConfig()['redirect_uri'] ?? null);
 
             return $accessToken;

--- a/src/Push.php
+++ b/src/Push.php
@@ -17,11 +17,13 @@ class Push
     private $clientId;
     private $secret;
 
-    public function __construct($clientId, $secret, Request $request)
+    public function __construct(Youzan $app)
     {
-        $this->clientId = $clientId;
-        $this->secret = $secret;
-        $this->request = $request;
+        $config = $app->getConfig();
+
+        $this->clientId = $app->getDev() ? $config['dev_client_id'] : $config['client_id'];
+        $this->secret = $app->getDev() ? $config['dev_client_secret'] : $config['client_secret'];
+        $this->request = $app['request'];
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -21,26 +21,15 @@ class ServiceProvider implements ServiceProviderInterface
     public function register(Container $pimple)
     {
         $pimple['access_token'] = function (Youzan $pimple) {
-            $config = $pimple->getConfig();
-            $accessToken = new AccessToken(
-                $pimple->getDev() ? $config['dev_client_id'] : $config['client_id'],
-                $pimple->getDev() ? $config['dev_client_secret'] : $config['client_secret'],
-                $pimple->getConfig()['kdt_id'] ?? null
-            );
-
-            return $accessToken;
+            return new AccessToken($pimple);
         };
 
-        $pimple['api'] = function ($pimple) {
+        $pimple['api'] = function (Youzan $pimple) {
             return new Api($pimple);
         };
 
         $pimple['push'] = function (Youzan $pimple) {
-            return new Push(
-                $pimple->getConfig()['client_id'],
-                $pimple->getConfig()['client_secret'],
-                $pimple['request']
-            );
+            return new Push($pimple);
         };
 
     }


### PR DESCRIPTION
解决更新到 php 8.0 后 `Attempt to read property "http" on null` 的问题
1. 相关问题 ref https://github.com/Hanson/foundation-sdk/commit/bee283ea22392b61f39a5e9ac505a70b5704acf7#commitcomment-90583526
1. Close #26 

- [ ] 更新后最低需要 hanson/foundation-sdk 4.0.3 的支持
- [ ] 已在本地测试 4.0.3 及 5.0+ 通过
- [ ] 不兼容 hanson/foundation-sdk 3.x 版本
- [ ] 不兼容 4.0.3 以下
- [ ] hanson/foundation-sdk 需要发布新版